### PR TITLE
Correct some dependencies in vehicle model user examples

### DIFF
--- a/mock_vehicle_model_shared_lib/CMakeLists.txt
+++ b/mock_vehicle_model_shared_lib/CMakeLists.txt
@@ -129,7 +129,7 @@ include_directories(
 ## Add cmake target dependencies of the library
 ## as an example, code may need to be generated before libraries
 ## either from message generation or dynamic reconfigure
-# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## Declare a C++ executable
 ## With catkin_make all packages are built within a single CMake context

--- a/mock_vehicle_model_user/CMakeLists.txt
+++ b/mock_vehicle_model_user/CMakeLists.txt
@@ -105,7 +105,7 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES ${PROJECT_NAME}
-#  CATKIN_DEPENDS lib_vehicle_model
+   CATKIN_DEPENDS lib_vehicle_model
 #  DEPENDS system_lib
 )
 


### PR DESCRIPTION
Some of the dependencies in the vehicle model example packages were missing. This occasionally results in build failures. This PR should hopefully resolve this. 