### PR TITLE
Foxy/develop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
     # Pull docker image from docker hub
     # XTERM used for better catkin_make output
     docker:
-      - image: usdotfhwastoldev/autoware.ai:develop
+      - image: usdotfhwastoldev/autoware.ai:foxy-develop
         user: carma
         environment:
           TERM: xterm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
     # Pull docker image from docker hub
     # XTERM used for better catkin_make output
     docker:
-      - image: usdotfhwastoldev/autoware.ai:foxy-develop
+      - image: usdotfhwastoldev/autoware.ai:develop
         user: carma
         environment:
           TERM: xterm
@@ -54,8 +54,8 @@ jobs:
           command: |
             source ${INIT_ENV}
             cd src
-            git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-utils.git --branch foxy/develop
-            git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch foxy/develop
+            git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-utils.git --branch develop
+            git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch develop
       - run:
           name: Build CARMAVehicleModelFramework
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,8 +53,8 @@ jobs:
           command: |
             source ${INIT_ENV}
             cd src
-            git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-utils.git --branch develop
-            git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch develop
+            git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-utils.git --branch foxy/develop
+            git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch foxy/develop
       - run:
           name: Build CARMAVehicleModelFramework
           command: |

--- a/lib_vehicle_model/CMakeLists.txt
+++ b/lib_vehicle_model/CMakeLists.txt
@@ -1,10 +1,9 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(lib_vehicle_model)
 
-## Compile as C++14, supported in ROS Noetic and newer
-add_compile_options(-std=c++14)
-set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
-set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+find_package(carma_cmake_common REQUIRED)
+carma_check_ros_version(1)
+carma_package()
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/lib_vehicle_model/package.xml
+++ b/lib_vehicle_model/package.xml
@@ -13,6 +13,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <depend>roscpp</depend>
+  <build_depend>carma_cmake_common</build_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/mock_vehicle_model_shared_lib/CMakeLists.txt
+++ b/mock_vehicle_model_shared_lib/CMakeLists.txt
@@ -1,10 +1,9 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(mock_vehicle_model_shared_lib)
 
-## Compile as C++14, supported in ROS Noetic and newer
-add_compile_options(-std=c++14)
-set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
-set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+find_package(carma_cmake_common REQUIRED)
+carma_check_ros_version(1)
+carma_package()
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/mock_vehicle_model_shared_lib/package.xml
+++ b/mock_vehicle_model_shared_lib/package.xml
@@ -11,6 +11,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <depend>lib_vehicle_model</depend>
+  <build_depend>carma_cmake_common</build_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/mock_vehicle_model_user/CMakeLists.txt
+++ b/mock_vehicle_model_user/CMakeLists.txt
@@ -1,10 +1,9 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(mock_vehicle_model_user)
 
-## Compile as C++14, supported in ROS Noetic and newer
-add_compile_options(-std=c++14)
-set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
-set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+find_package(carma_cmake_common REQUIRED)
+carma_check_ros_version(1)
+carma_package()
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/mock_vehicle_model_user/package.xml
+++ b/mock_vehicle_model_user/package.xml
@@ -13,7 +13,7 @@
   <depend>roscpp</depend>
   <depend>std_msgs</depend>
 
-
+  <build_depend>carma_cmake_common</build_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/model_test_tools/CMakeLists.txt
+++ b/model_test_tools/CMakeLists.txt
@@ -1,10 +1,9 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(model_test_tools)
 
-## Compile as C++14, supported in ROS Noetic and newer
-add_compile_options(-std=c++14)
-set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
-set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+find_package(carma_cmake_common REQUIRED)
+carma_check_ros_version(1)
+carma_package()
 
 ## Find catkin macros and libraries
 find_package(catkin REQUIRED COMPONENTS

--- a/model_test_tools/package.xml
+++ b/model_test_tools/package.xml
@@ -13,6 +13,7 @@
   <depend>lib_vehicle_model</depend>
   <depend>tf2</depend>
   <depend>geometry_msgs</depend>
+  <build_depend>carma_cmake_common</build_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/passenger_car_dynamic_model/CMakeLists.txt
+++ b/passenger_car_dynamic_model/CMakeLists.txt
@@ -1,10 +1,9 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(passenger_car_dynamic_model)
 
-## Compile as C++14, supported in ROS Noetic and newer
-add_compile_options(-std=c++14)
-set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
-set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+find_package(carma_cmake_common REQUIRED)
+carma_check_ros_version(1)
+carma_package()
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/passenger_car_dynamic_model/package.xml
+++ b/passenger_car_dynamic_model/package.xml
@@ -13,7 +13,7 @@
   <buildtool_depend>catkin</buildtool_depend>
   <depend>lib_vehicle_model</depend>
   <depend>ompl</depend>
-
+  <build_depend>carma_cmake_common</build_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/passenger_car_kinematic_model/CMakeLists.txt
+++ b/passenger_car_kinematic_model/CMakeLists.txt
@@ -1,10 +1,9 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(passenger_car_kinematic_model)
 
-## Compile as C++14, supported in ROS Noetic and newer
-add_compile_options(-std=c++14)
-set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
-set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+find_package(carma_cmake_common REQUIRED)
+carma_check_ros_version(1)
+carma_package()
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/passenger_car_kinematic_model/package.xml
+++ b/passenger_car_kinematic_model/package.xml
@@ -24,6 +24,7 @@
   <test_depend>model_test_tools</test_depend>
   <test_depend>sigpack</test_depend>
   <test_depend>gps_common</test_depend>
+  <build_depend>carma_cmake_common</build_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Merge foxy/develop into develop to mainline ROS2 code 
<!--- Describe your changes in detail -->

## Related Issue
Supports https://github.com/usdot-fhwa-stol/carma-platform/issues/1609
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Required to support ROS2 migration and development
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
foxy/develop has been tested on the silver lexus though more testing will be needed following merge into develop
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
