### PR TITLE
Update sonar-scanner.properties

### DIFF
--- a/.sonarqube/sonar-scanner.properties
+++ b/.sonarqube/sonar-scanner.properties
@@ -20,6 +20,9 @@ sonar.cfamily.build-wrapper-output=/opt/carma/bw-output
 sonar.host.url=https://sonarcloud.io
 sonar.sources=src/main
 sonar.cfamily.gcov.reportsPath=/opt/carma/coverage_reports/gcov
+sonar.coverageReportPaths=/opt/carma/coverage_reports/gcov/coverage.xml
+sonar.cpp.file.suffixes=.cpp,.h,.tpp
+sonar.c.file.suffixes=-
 sonar.tests=src/test
 # Set Git as SCM sensor
 sonar.scm.disabled=false
@@ -37,9 +40,11 @@ mock_vehicle_model_user.sonar.projectBaseDir=/opt/carma/src/CARMAVehicleModelFra
 # C++ Package differences
 # Sources
 lib_vehicle_model.sonar.sources=src
+lib_vehicle_model.sonar.exclusions  =test/**
 mock_vehicle_model_shared_lib.sonar.sources=src
 mock_vehicle_model_user.sonar.sources=src
 passenger_car_kinematic_model.sonar.sources=src
+passenger_car_kinematic_model.sonar.exclusions  =test/**
 # Tests
 # Note: For C++ setting this field does not cause test analysis to occur. It only allows the test source code to be evaluated.
 lib_vehicle_model.sonar.tests=test


### PR DESCRIPTION
This PR is to update the sonar properties with correct output path for coverage.xml output format after the Carma-base coverage script are updated